### PR TITLE
Install heroku dependency in example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ jobs:
 
 ### ⬇ IMPORTANT PART ⬇ ###
 
+      - name: Install Heroku CLI
+        run: |
+          curl https://cli-assets.heroku.com/install.sh | sh
+
       - name: Build, Push and Release a Docker container to Heroku. # Your custom step name
         uses: gonuit/heroku-docker-deploy@v1.3.3 # GitHub action name (leave it as it is).
         with:


### PR DESCRIPTION
Last year heroku-docker-deploy was working, however now the deploy fails with this error in my github action run:

```
Error: Releasing docker container failed.
Error: spawn heroku ENOENT
```

I resolved the issue by Installing heroku before the heroku-docker-deploy step. 

This PR documents this dependency in the README.